### PR TITLE
Add cast to and from GUID

### DIFF
--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -148,6 +148,9 @@ namespace System // wa-o, System Namespace!?
             randomness8 = (byte)((CharToBase32[base32[22]] << 7) | (CharToBase32[base32[23]] << 2) | (CharToBase32[base32[24]] >> 3));
         }
 
+        // TODO: Is there a way to extract a GUID's internal value without allocation?
+        public Ulid(Guid guid) : this(guid.ToByteArray()) { }
+
         // Factory
 
         public static Ulid NewUlid()
@@ -353,6 +356,47 @@ namespace System // wa-o, System Namespace!?
             if (this.randomness9 != other.randomness9) return GetResult(this.randomness9, other.randomness9);
 
             return 0;
+        }
+
+        public static explicit operator Guid(Ulid _this)
+        {
+            return _this.ToGuid();
+        }
+
+        /// <summary>
+        /// Convert this <c>Ulid</c> value to a <c>Guid</c> value with the same byte layout.
+        /// </summary>
+        /// <returns>The converted <c>Guid</c> value</returns>
+        public Guid ToGuid()
+        {
+            int guid_0_4 =
+                this.timestamp0 << 0 |
+                this.timestamp1 << 8 |
+                this.timestamp2 << 16 |
+                this.timestamp3 << 24;
+
+            short guid_4_6 =
+                (short)(
+                    this.timestamp4 << 0 |
+                    this.timestamp5 << 8);
+
+            short guid_6_8 =
+                (short)(
+                    this.randomness0 << 0 |
+                    this.randomness1 << 8);
+
+            return new Guid(
+                guid_0_4,
+                guid_4_6,
+                guid_6_8,
+                this.randomness2,
+                this.randomness3,
+                this.randomness4,
+                this.randomness5,
+                this.randomness6,
+                this.randomness7,
+                this.randomness8,
+                this.randomness9);
         }
     }
 }

--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -382,7 +382,7 @@ namespace System // wa-o, System Namespace!?
         /// Convert this <c>Ulid</c> value to a <c>Guid</c> value with the same comparability.
         /// </summary>
         /// <remarks>
-        /// The byte arrangement between Ulid and Guid is not preserved. The 
+        /// The byte arrangement between Ulid and Guid is not preserved.
         /// </remarks>
         /// <returns>The converted <c>Guid</c> value</returns>
         public Guid ToGuid()

--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -149,7 +149,26 @@ namespace System // wa-o, System Namespace!?
         }
 
         // TODO: Is there a way to extract a GUID's internal value without allocation?
-        public Ulid(Guid guid) : this(guid.ToByteArray()) { }
+        public Ulid(Guid guid)
+        {
+            var byteArray = guid.ToByteArray();
+            this.timestamp0 = byteArray[3];
+            this.timestamp1 = byteArray[2];
+            this.timestamp2 = byteArray[1];
+            this.timestamp3 = byteArray[0];
+            this.timestamp4 = byteArray[5];
+            this.timestamp5 = byteArray[4];
+            this.randomness0 = byteArray[7];
+            this.randomness1 = byteArray[6];
+            this.randomness2 = byteArray[8];
+            this.randomness3 = byteArray[9];
+            this.randomness4 = byteArray[10];
+            this.randomness5 = byteArray[11];
+            this.randomness6 = byteArray[12];
+            this.randomness7 = byteArray[13];
+            this.randomness8 = byteArray[14];
+            this.randomness9 = byteArray[15];
+        }
 
         // Factory
 
@@ -364,26 +383,29 @@ namespace System // wa-o, System Namespace!?
         }
 
         /// <summary>
-        /// Convert this <c>Ulid</c> value to a <c>Guid</c> value with the same byte layout.
+        /// Convert this <c>Ulid</c> value to a <c>Guid</c> value with the same comparability.
         /// </summary>
+        /// <remarks>
+        /// The byte arrangement between Ulid and Guid is not preserved. The 
+        /// </remarks>
         /// <returns>The converted <c>Guid</c> value</returns>
         public Guid ToGuid()
         {
             int guid_0_4 =
-                this.timestamp0 << 0 |
-                this.timestamp1 << 8 |
-                this.timestamp2 << 16 |
-                this.timestamp3 << 24;
+                this.timestamp0 << 24 |
+                this.timestamp1 << 16 |
+                this.timestamp2 << 8 |
+                this.timestamp3 << 0;
 
             short guid_4_6 =
                 (short)(
-                    this.timestamp4 << 0 |
-                    this.timestamp5 << 8);
+                    this.timestamp4 << 8 |
+                    this.timestamp5 << 0);
 
             short guid_6_8 =
                 (short)(
-                    this.randomness0 << 0 |
-                    this.randomness1 << 8);
+                    this.randomness0 << 8 |
+                    this.randomness1 << 0);
 
             return new Guid(
                 guid_0_4,

--- a/tests/Ulid.Tests/UlidTest.cs
+++ b/tests/Ulid.Tests/UlidTest.cs
@@ -67,5 +67,15 @@ namespace UlidTests
             first.ToString().Should().BeEquivalentTo(second.ToString());
             // Console.WriteLine($"first={first.ToString()}, second={second.ToString()}");
         }
+
+        [Fact]
+        public void GuidInterop()
+        {
+            var ulid = Ulid.NewUlid();
+            var guid = ulid.ToGuid();
+            var ulid2 = new Ulid(guid);
+
+            ulid2.Should().BeEquivalentTo(ulid, "a Ulid-Guid roundtrip should result in identical values");
+        }
     }
 }

--- a/tests/Ulid.Tests/UlidTest.cs
+++ b/tests/Ulid.Tests/UlidTest.cs
@@ -77,5 +77,20 @@ namespace UlidTests
 
             ulid2.Should().BeEquivalentTo(ulid, "a Ulid-Guid roundtrip should result in identical values");
         }
+
+        [Fact]
+        public void GuidComparison()
+        {
+            var data_smaller = new byte[] { 0, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var data_larger = new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var ulid_smaller = new Ulid(data_smaller);
+            var ulid_larger = new Ulid(data_larger);
+
+            var guid_smaller = ulid_smaller.ToGuid();
+            var guid_larger = ulid_larger.ToGuid();
+
+            ulid_smaller.CompareTo(ulid_larger).Should().BeLessThan(0, "a Ulid comparison should compare byte to byte");
+            guid_smaller.CompareTo(guid_larger).Should().BeLessThan(0, "a Ulid to Guid cast should preserve order");
+        }
     }
 }


### PR DESCRIPTION
This pull request adds casts to and from GUID, as well as tests for them. The cast preserves ordering but not byte arrangement.

The added items are:

- `Ulid.ToGuid()`
- explicit cast to `Guid` (`(Guid)ulidInstance`)
- Constructor `new Ulid(guid)`

**This cast is not the same as `NUlid.ToGuid()`!**

## Notes

According to [Documentation on `Guid` type](https://docs.microsoft.com/en-us/dotnet/api/system.guid.compareto), comparison between `Guid`s is done as the following:

- Compare the first 4 bytes as a little-endian integer
- Compare the next 2 bytes as a little-endian integer
- Compare the next 2 bytes as a little-endian integer
- Compare the remaining bytes byte by byte

To preserve ordering, we must encode the first 8 bytes as little-endian integers, thus changing the byte arrangement.