### PR TITLE
chore: skip fork build for unity

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -3,7 +3,7 @@ name: Build-Debug
 on:
   push:
     branches:
-      - "**"
+      - "master"
     tags:
       - "!*" # not a tag push
   pull_request:
@@ -35,6 +35,7 @@ jobs:
       - run: dotnet test -c Debug ./tests/Ulid.SystemTextJson.Tests
 
   build-unity:
+    if: "(github.event == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:')"
     strategy:
       matrix:
         unity: ["2019.3.9f1", "2020.1.0b5"]


### PR DESCRIPTION
## TL;DR

fork repo's PR can't refer secrets. Let's skip unity build for fork PR.

* skip Unity build for fork repo.
* push build will trigger only for `mater` branch. (not for each branch push)