### PR TITLE
chore: replace set-env to ENV FILE $GITHUB_ENV 

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.201
+          dotnet-version: 3.1.x
 
       # build CommandTools first (using dotnet run command in ZLogger.csproj)
       - run: dotnet build -c Debug src/Ulid

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.201
+          dotnet-version: 3.1.x
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # build CommandTools first (using dotnet run command in ZLogger.csproj)
       - run: dotnet build -c Release src/Ulid -p:Version=${{ env.GIT_TAG }}
@@ -60,7 +60,7 @@ jobs:
       - run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
 
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # Execute scripts: Export Package
       - name: Export unitypackage
@@ -88,7 +88,7 @@ jobs:
         with:
           dotnet-version: 3.1.201
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # Create Releases
       - uses: actions/create-release@v1


### PR DESCRIPTION
* fix https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* use latest dotnet 3.1