### PR TITLE
Retargeting to netcoreapp2.1, netcoreapp3.1 and net5

### DIFF
--- a/src/Ulid.MessagePack/Ulid.MessagePack.csproj
+++ b/src/Ulid.MessagePack/Ulid.MessagePack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>release.snk</AssemblyOriginatorKeyFile>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Ulid.SystemTextJson/Ulid.SystemTextJson.csproj
+++ b/src/Ulid.SystemTextJson/Ulid.SystemTextJson.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
         <DefineConstants>SYSTEM_TEXT_JSON</DefineConstants>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>release.snk</AssemblyOriginatorKeyFile>

--- a/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
+++ b/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
@@ -15,7 +15,7 @@ namespace System // wa-o, System Namespace!?
     [StructLayout(LayoutKind.Explicit, Size = 16)]
     [DebuggerDisplay("{ToString(),nq}")]
     [TypeConverter(typeof(UlidTypeConverter))]
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1 || NET5_0
     [System.Text.Json.Serialization.JsonConverter(typeof(Cysharp.Serialization.Json.UlidJsonConverter))]
 #endif
     public partial struct Ulid : IEquatable<Ulid>, IComparable<Ulid>

--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -15,7 +15,7 @@ namespace System // wa-o, System Namespace!?
     [StructLayout(LayoutKind.Explicit, Size = 16)]
     [DebuggerDisplay("{ToString(),nq}")]
     [TypeConverter(typeof(UlidTypeConverter))]
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1 || NET5_0
     [System.Text.Json.Serialization.JsonConverter(typeof(Cysharp.Serialization.Json.UlidJsonConverter))]
 #endif
     public partial struct Ulid : IEquatable<Ulid>, IComparable<Ulid>

--- a/src/Ulid/Ulid.csproj
+++ b/src/Ulid/Ulid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>System</RootNamespace>
         <SignAssembly>true</SignAssembly>
@@ -13,8 +13,12 @@
         <Description>Fast .NET Standard(C#) Implementation of ULID.</Description>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
         <PackageReference Include="System.Memory" Version="4.5.2" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">        
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     </ItemGroup>
 

--- a/src/Ulid/UlidJsonConverter.cs
+++ b/src/Ulid/UlidJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_0 || SYSTEM_TEXT_JSON
+﻿#if NETCOREAPP3_1 || NET5_0 || SYSTEM_TEXT_JSON
 
 using System;
 using System.Buffers;


### PR DESCRIPTION
Retargeting the projects from netcoreapp3.0 (which is deprecated) to:
- netcoreapp2.1 (LTS)
- netcoreapp3.1 (LTS)
- net5 (current stable)

Removed nuget depedencies for those assemblies which are included in netcorapp, while maintaining the same depedencies for netstandard2.0 (for compatibility).

fixes #17 