### PR TITLE
fix: Adjust the Parse method to throw as expected if it doesn't receive a valid input

### DIFF
--- a/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
+++ b/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
@@ -193,7 +193,7 @@ namespace System // wa-o, System Namespace!?
 
         public static Ulid Parse(string base32)
         {
-            return new Ulid(base32.AsSpan());
+            return Parse(base32.AsSpan());
         }
 
         public static Ulid Parse(ReadOnlySpan<char> base32)

--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -193,7 +193,7 @@ namespace System // wa-o, System Namespace!?
 
         public static Ulid Parse(string base32)
         {
-            return new Ulid(base32.AsSpan());
+            return Parse(base32.AsSpan());
         }
 
         public static Ulid Parse(ReadOnlySpan<char> base32)

--- a/tests/Ulid.Tests/UlidTest.cs
+++ b/tests/Ulid.Tests/UlidTest.cs
@@ -92,5 +92,12 @@ namespace UlidTests
             ulid_smaller.CompareTo(ulid_larger).Should().BeLessThan(0, "a Ulid comparison should compare byte to byte");
             guid_smaller.CompareTo(guid_larger).Should().BeLessThan(0, "a Ulid to Guid cast should preserve order");
         }
+
+        [Fact]
+        public void UlidParseRejectsInvalidStrings()
+        {
+            Assert.Throws<ArgumentException>(() => Ulid.Parse("1234"));
+            Assert.Throws<ArgumentException>(() => Ulid.Parse(Guid.NewGuid().ToString()));
+        }
     }
 }

--- a/tests/Ulid.Tests/UlidTest.cs
+++ b/tests/Ulid.Tests/UlidTest.cs
@@ -99,5 +99,12 @@ namespace UlidTests
             Assert.Throws<ArgumentException>(() => Ulid.Parse("1234"));
             Assert.Throws<ArgumentException>(() => Ulid.Parse(Guid.NewGuid().ToString()));
         }
+
+        [Fact]
+        void UlidTryParseFailsForInvalidStrings()
+        {
+            Assert.False(Ulid.TryParse("1234", out _));
+            Assert.False(Ulid.TryParse(Guid.NewGuid().ToString(), out _));
+        }
     }
 }


### PR DESCRIPTION
Fixes #19.

Changed to use the Parse overload that actually has the validation instead of directly using the `new Ulid()` constructor.