### PR TITLE
chore: fix release tag to use tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -160,8 +160,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Ver.${{ github.ref }}
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: Ver.${{ env.GIT_TAG }}
+          draft: true
+          prerelease: false
 
       # Download (All) Artifacts to current directory
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
## TL;DR

fix broken tag.
use GIT_TAG instead of `github.ref`.

![image](https://user-images.githubusercontent.com/3856350/106683215-72195880-6607-11eb-8aa0-0efc09184eb4.png)

![image](https://user-images.githubusercontent.com/3856350/106683221-75acdf80-6607-11eb-833c-b575b9148be4.png)

![image](https://user-images.githubusercontent.com/3856350/106683242-7d6c8400-6607-11eb-91fc-b177a4e23aaa.png)
