### PR TITLE
fix: create release should refer after push sha

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -142,7 +142,7 @@ jobs:
 
   create-release:
     if: github.event.inputs.dry_run == 'false'
-    needs: [build-dotnet, build-unity]
+    needs: [update-packagejson, build-dotnet, build-unity]
     runs-on: ubuntu-latest
     env:
       GIT_TAG: ${{ github.event.inputs.tag }}
@@ -162,6 +162,7 @@ jobs:
         with:
           tag_name: ${{ env.GIT_TAG }}
           release_name: Ver.${{ env.GIT_TAG }}
+          commitish: ${{ needs.update-packagejson.outputs.sha }}
           draft: true
           prerelease: false
 


### PR DESCRIPTION
## TL;DR

fix release included package.json is old.

## Summary

create_release looking into github.ref by default, but it should see after push sha.

> ref: https://github.com/actions/create-release

![image](https://user-images.githubusercontent.com/3856350/106711378-c5f16500-663a-11eb-83e4-7d6e7d20128f.png)
