### PR TITLE
Ulid Inverse

### DIFF
--- a/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
+++ b/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
@@ -34,7 +34,7 @@ namespace System // wa-o, System Namespace!?
 
         // Core
 
-        // Timestamp(64bits)
+        // Timestamp(48bits)
         [FieldOffset(0)] readonly byte timestamp0;
         [FieldOffset(1)] readonly byte timestamp1;
         [FieldOffset(2)] readonly byte timestamp2;
@@ -279,6 +279,32 @@ namespace System // wa-o, System Namespace!?
             Unsafe.Add(ref Unsafe.As<Ulid, byte>(ref ulid), 14) = (byte)((CharToBase32[base32[22]] << 7) | (CharToBase32[base32[23]] << 2) | (CharToBase32[base32[24]] >> 3));
 
             return ulid;
+        }
+
+        // Inverse 
+        public Ulid Inverse()
+        {
+            byte[] invertedBytes = new byte[16];
+
+            invertedBytes[0] = (byte)~this.timestamp0;
+            invertedBytes[1] = (byte)~this.timestamp1;
+            invertedBytes[2] = (byte)~this.timestamp2;
+            invertedBytes[3] = (byte)~this.timestamp3;
+            invertedBytes[4] = (byte)~this.timestamp4;
+            invertedBytes[5] = (byte)~this.timestamp5;
+
+            invertedBytes[6] = (byte)~this.randomness0;
+            invertedBytes[7] = (byte)~this.randomness1;
+            invertedBytes[8] = (byte)~this.randomness2;
+            invertedBytes[9] = (byte)~this.randomness3;
+            invertedBytes[10] = (byte)~this.randomness4;
+            invertedBytes[11] = (byte)~this.randomness5;
+            invertedBytes[12] = (byte)~this.randomness6;
+            invertedBytes[13] = (byte)~this.randomness7;
+            invertedBytes[14] = (byte)~this.randomness8;
+            invertedBytes[15] = (byte)~this.randomness9;
+
+            return new Ulid(invertedBytes);
         }
 
         // Convert

--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -281,6 +281,32 @@ namespace System // wa-o, System Namespace!?
             return ulid;
         }
 
+        // Inverse 
+        public Ulid Inverse()
+        {
+            byte[] invertedBytes = new byte[16];
+
+            invertedBytes[0] = (byte)~this.timestamp0;
+            invertedBytes[1] = (byte)~this.timestamp1;
+            invertedBytes[2] = (byte)~this.timestamp2;
+            invertedBytes[3] = (byte)~this.timestamp3;
+            invertedBytes[4] = (byte)~this.timestamp4;
+            invertedBytes[5] = (byte)~this.timestamp5;
+
+            invertedBytes[6] = (byte)~this.randomness0;
+            invertedBytes[7] = (byte)~this.randomness1;
+            invertedBytes[8] = (byte)~this.randomness2;
+            invertedBytes[9] = (byte)~this.randomness3;
+            invertedBytes[10] = (byte)~this.randomness4;
+            invertedBytes[11] = (byte)~this.randomness5;
+            invertedBytes[12] = (byte)~this.randomness6;
+            invertedBytes[13] = (byte)~this.randomness7;
+            invertedBytes[14] = (byte)~this.randomness8;
+            invertedBytes[15] = (byte)~this.randomness9;
+
+            return new Ulid(invertedBytes);
+        }
+
         // Convert
 
         public byte[] ToByteArray()

--- a/tests/Ulid.Tests/UlidTest.cs
+++ b/tests/Ulid.Tests/UlidTest.cs
@@ -106,5 +106,14 @@ namespace UlidTests
             Assert.False(Ulid.TryParse("1234", out _));
             Assert.False(Ulid.TryParse(Guid.NewGuid().ToString(), out _));
         }
+
+        [Fact]
+        void UlidInverse()
+        {
+            var ulid = Ulid.Parse("01H5M9J9BM30QWKHQGPY01AHPC");
+            var inverseUlid = Ulid.Parse("7YETBPDPMBWZ83CE8F91ZYNE9K");
+
+            inverseUlid.Should().BeEquivalentTo(ulid.Inverse());
+        }
     }
 }

--- a/tests/Ulid.Tests/UlidTest.cs
+++ b/tests/Ulid.Tests/UlidTest.cs
@@ -113,6 +113,7 @@ namespace UlidTests
             var ulid = Ulid.Parse("01H5M9J9BM30QWKHQGPY01AHPC");
             var inverseUlid = Ulid.Parse("7YETBPDPMBWZ83CE8F91ZYNE9K");
 
+            ulid.Should().BeEquivalentTo(inverseUlid.Inverse());
             inverseUlid.Should().BeEquivalentTo(ulid.Inverse());
         }
     }


### PR DESCRIPTION
I wanted the inverse of the Ulid for DynamoDB. DynamoDB has very limited queryablity. I have a certain scenario where having a reverse would be beneficial.  

If this has not been introduced into the official Ulid, you can find and extension method in WebTruss.UlidExtentions.

The inverse of the first character is not the true inverse because ulid is doing some bitwise operations which I don't really understand.