### PR TITLE
Fixed Entity Framework Core integration steps and explained integration more thoroughly

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ public class UlidToBytesConverter : ValueConverter<Ulid, byte[]>
 {
     private static readonly ConverterMappingHints defaultHints = new ConverterMappingHints(size: 16);
 
+    public UlidToBytesConverter() : this(null)
+    {
+    }
+
     public UlidToBytesConverter(ConverterMappingHints mappingHints = null)
         : base(
                 convertToProviderExpression: x => x.ToByteArray(),
@@ -247,6 +251,10 @@ public class UlidToStringConverter : ValueConverter<Ulid, string>
 {
     private static readonly ConverterMappingHints defaultHints = new ConverterMappingHints(size: 26);
 
+    public UlidToStringConverter() : this(null)
+    {
+    }
+
     public UlidToStringConverter(ConverterMappingHints mappingHints = null)
         : base(
                 convertToProviderExpression: x => x.ToString(),
@@ -254,6 +262,29 @@ public class UlidToStringConverter : ValueConverter<Ulid, string>
                 mappingHints: defaultHints.With(mappingHints))
     {
     }
+}
+```
+
+To use those converters, you can either specify individual properties of entities in `OnModelCreating` method of your context:
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<MyEntity>()
+        .Property(e => e.MyProperty)
+        .HasConversion<UlidToStringConverter>()
+        .HasConversion<UlidToBytesConverter>();
+}
+```
+
+or use model bulk configuration for all properties of type `Ulid`. To do this, overload `ConfigureConventions` method of your context:
+
+```csharp
+protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+{
+    configurationBuilder
+        .Properties<Ulid>()
+        .HaveConversion<UlidToStringConverter>()
+        .HaveConversion<UlidToBytesConverter>();
 }
 ```
 


### PR DESCRIPTION
Hi, I tried to use this library in my project and I've found that the Entity Framework Core integration code snippet was missing parameterless constructors, as I got this exception during creation of migrations:

```
System.InvalidOperationException: "Cannot create an instance of value converter type 'UlidToStringConverter'. Ensure that the type can be instantiated and has a parameterless constructor, or use the overload of 'HasConversion' that accepts a delegate."
```

I used the same solution as [here](https://github.com/SteveDunn/Vogen/issues/116).

Moreover, I added further steps on how to use those `ValueConverters` so that the library is easy to use for experienced and inexperienced programmers alike.

Please let me know if there are any issues with my PR, I will gladly make all the necessary changes. I'm new to contributing to public repositories :) 