### PR TITLE
Add MinAt and MaxAt static methods

### DIFF
--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -43,9 +43,12 @@ namespace System // wa-o, System Namespace!?
         static readonly byte[] CharToBase32 = new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 255, 255, 255, 255, 255, 255, 255, 10, 11, 12, 13, 14, 15, 16, 17, 255, 18, 19, 255, 20, 21, 255, 22, 23, 24, 25, 26, 255, 27, 28, 29, 30, 31, 255, 255, 255, 255, 255, 255, 10, 11, 12, 13, 14, 15, 16, 17, 255, 18, 19, 255, 20, 21, 255, 22, 23, 24, 25, 26, 255, 27, 28, 29, 30, 31 };
         static readonly DateTimeOffset UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        public static readonly Ulid MinValue = new Ulid(UnixEpoch.ToUnixTimeMilliseconds(), new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+        static readonly byte[] MinRandomness = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        static readonly byte[] MaxRandomness = new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 };
 
-        public static readonly Ulid MaxValue = new Ulid(DateTimeOffset.MaxValue.ToUnixTimeMilliseconds(), new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 });
+        public static readonly Ulid MinValue = new Ulid(UnixEpoch.ToUnixTimeMilliseconds(), MinRandomness);
+
+        public static readonly Ulid MaxValue = new Ulid(DateTimeOffset.MaxValue.ToUnixTimeMilliseconds(), MaxRandomness);
 
         public static readonly Ulid Empty = new Ulid();
 
@@ -268,6 +271,16 @@ namespace System // wa-o, System Namespace!?
         {
             if (randomness.Length != 10) throw new ArgumentException("invalid randomness length, length:" + randomness.Length);
             return new Ulid(timestamp.ToUnixTimeMilliseconds(), randomness);
+        }
+
+        public static Ulid MinAt(DateTimeOffset timestamp)
+        {
+            return new Ulid(timestamp.ToUnixTimeMilliseconds(), MinRandomness);
+        }
+
+        public static Ulid MaxAt(DateTimeOffset timestamp)
+        {
+            return new Ulid(timestamp.ToUnixTimeMilliseconds(), MaxRandomness);
         }
 
         public static Ulid Parse(string base32)
@@ -705,5 +718,5 @@ namespace System // wa-o, System Namespace!?
             throw new NotImplementedException();
         }
 #endif
-            }
+    }
 }


### PR DESCRIPTION
# Description
This PR adds a couple of static methods that work similarly.

MinAt:
Generates the minimum possible `Ulid` given a `DateTimeOffset`

MaxAt:
Generates the maximum possible `Ulid` given a `DateTimeOffset`

# Reason
We have been using `Ulid` and this library for a while and it's quite great with pagination. But in order to use that, we sometimes have to do `var idGte = Ulid.NewUlid(createdAtGte, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 })` to compare it against the primary key

# Solution
Theses minute methods would make the code more readable e.g.: `var idGte = Ulid.MinAt(createdAtGte)`