### PR TITLE
feat: add `(Write/Read)AsPropertyName` methods

### DIFF
--- a/src/Ulid/UlidJsonConverter.cs
+++ b/src/Ulid/UlidJsonConverter.cs
@@ -16,7 +16,8 @@ namespace Cysharp.Serialization.Json
         {
             try
             {
-                if (reader.TokenType != JsonTokenType.String) throw new JsonException("Expected string");
+                if (reader.TokenType != JsonTokenType.String && reader.TokenType != JsonTokenType.PropertyName)
+                    throw new JsonException("Expected string or property name");
 
                 if (reader.HasValueSequence)
                 {
@@ -52,6 +53,19 @@ namespace Cysharp.Serialization.Json
             Span<byte> buf = stackalloc byte[26];
             value.TryWriteStringify(buf);
             writer.WriteStringValue(buf);
+        }
+
+        public override void WriteAsPropertyName(Utf8JsonWriter writer, Ulid value, JsonSerializerOptions options)
+        {
+            Span<byte> buf = stackalloc byte[26];
+            value.TryWriteStringify(buf);
+            writer.WritePropertyName(buf);
+        }
+
+        public override Ulid ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            return Read(ref reader, typeToConvert, options);
         }
     }
 }

--- a/tests/Ulid.SystemTextJson.Tests/UlidJsonConverterTest.cs
+++ b/tests/Ulid.SystemTextJson.Tests/UlidJsonConverterTest.cs
@@ -14,6 +14,11 @@ namespace UlidTests
         {
             public Ulid value { get; set; }
         }
+        
+        class TestDictionarySerializationClass
+        {
+            public Dictionary<Ulid, int> value { get; set; }
+        }
 
         JsonSerializerOptions GetOptions()
         {
@@ -80,6 +85,19 @@ namespace UlidTests
 
             var serialized = JsonSerializer.Serialize(groundTruth);
             var deserialized = JsonSerializer.Deserialize<TestSerializationClass>(serialized);
+            deserialized.value.Should().BeEquivalentTo(groundTruth.value, "JSON serialize roundtrip");
+        }
+        
+        [Fact]
+        public void SerializeWithPropertyNameTest()
+        {
+            var groundTruth = new TestDictionarySerializationClass()
+            {
+                value = new Dictionary<Ulid, int>() { { Ulid.NewUlid(), 1 } }
+            };
+
+            var serialized = JsonSerializer.Serialize(groundTruth, GetOptions());
+            var deserialized = JsonSerializer.Deserialize<TestDictionarySerializationClass>(serialized, GetOptions());
             deserialized.value.Should().BeEquivalentTo(groundTruth.value, "JSON serialize roundtrip");
         }
     }


### PR DESCRIPTION
Currently, Ulids cannot be used as dictionary keys when serializing to JSON. i.e. `IDictionary<Ulid, int>()` will not serialize correctly with the error:

```
System.NotSupportedException
The type 'System.Ulid' is not a supported dictionary key using converter of type 'Cysharp.Serialization.Json.UlidJsonConverter'. 
```

This PR adds support for `WriteAsPropertyName` and `ReadAsPropertyName` to allow for this use case.