### PR TITLE
Allow running tool on latest&greatest

### DIFF
--- a/src/Ulid.Cli/Ulid.Cli.csproj
+++ b/src/Ulid.Cli/Ulid.Cli.csproj
@@ -17,6 +17,8 @@
         <PackAsTool>true</PackAsTool>
         <LangVersion>7.3</LangVersion>
         <IsPackable>true</IsPackable>
+        <!-- Allow running on whatever latest version users have. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+        <RollForward>LatestMajor</RollForward>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
It's highly unlikely that a future vesion of the dotnet runtime will break things so fundamentally that the Ulid CLI would fail. Therefore, rather than failing to start as time goes by and new versions of dotnet become prevalent and the current ones targeted by the project become obsolete, let the tool run on whatever version the user has (latest major even).

This setting (for example) would have allowed the existing published build targeting the STS .net7 to run on .net8 or even .net9/10 soon, without any issues.

As it is now, however, users get an error instead:

```
pwsh> dotnet ulid
You must install or update .NET to run this application.

App: C:\Users\[user]\.dotnet\tools\dotnet-ulid.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '7.0.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  6.0.36 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.16 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  9.0.5 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=x64&rid=win-x64&os=win10
```

Which is quite a bad user experience.