### PR TITLE
ci: add id-token: write for NuGet Trusted Publish

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -101,6 +101,7 @@ jobs:
     needs: [update-packagejson, build-dotnet, build-unity]
     permissions:
       contents: write
+      id-token: write # required for NuGet Trusted Publish
     uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
     with:
       commit-id: ${{ needs.update-packagejson.outputs.sha }}


### PR DESCRIPTION
## Summary

This PR enables `release.yaml` to publish NuGet packages via [NuGet Trusted Publish](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/). 
This means we no longer depend on a Personal Access Token (PAT) to publish .nupkg packages.