### PR TITLE
Improved Equals performance

### DIFF
--- a/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
+++ b/src/Ulid.Unity/Assets/Scripts/Ulid/Ulid.cs
@@ -582,7 +582,10 @@ namespace System // wa-o, System Namespace!?
             ref var rB = ref Unsafe.As<Ulid, long>(ref Unsafe.AsRef(in right));
 
             // Compare each element
-            return rA == rB && Unsafe.Add(ref rA, 1) == Unsafe.Add(ref rB, 1);
+            var xorA = rA ^ rB;
+            var xorB = Unsafe.Add(ref rA, 1) ^ Unsafe.Add(ref rB, 1);
+
+            return (xorA | xorB) == 0;
         }
 
         public bool Equals(Ulid other) => EqualsCore(this, other);

--- a/src/Ulid/Ulid.cs
+++ b/src/Ulid/Ulid.cs
@@ -582,7 +582,10 @@ namespace System // wa-o, System Namespace!?
             ref var rB = ref Unsafe.As<Ulid, long>(ref Unsafe.AsRef(in right));
 
             // Compare each element
-            return rA == rB && Unsafe.Add(ref rA, 1) == Unsafe.Add(ref rB, 1);
+            var xorA = rA ^ rB;
+            var xorB = Unsafe.Add(ref rA, 1) ^ Unsafe.Add(ref rB, 1);
+
+            return (xorA | xorB) == 0;
         }
 
         public bool Equals(Ulid other) => EqualsCore(this, other);


### PR DESCRIPTION
Improved Equals performance by replacing branching instructions with XORs on older .NET standards. Benchmark from my machine

* Equals

| Method | Mean | Error | Ratio | Gen0 | Allocated | Alloc Ratio |
|------- |-----------:|------:|------:|-------:|----------:|------------:|
|  Guid_ |  1.2188 ns |    NA |  1.00 |      - |         - |          NA |
|  Ulid_ |  0.2299 ns |    NA |  0.19 |      - |         - |          NA |
| NUlid_ | 14.7996 ns |    NA | 12.14 | 0.0061 |      80 B |          NA |

I would appreciate somebody validating my method before approving.